### PR TITLE
Fix PWM sound

### DIFF
--- a/S32X.sv
+++ b/S32X.sv
@@ -1002,13 +1002,13 @@ always_comb begin
 		g = color_lut[GEN_G];
 		b = color_lut[GEN_B];
 	end else if (!VDP_MD_EN && VDP_32X_EN) begin
-		r = {S32X_R,S32X_R[0],S32X_R[0],S32X_R[0]};
-		g = {S32X_G,S32X_G[0],S32X_G[0],S32X_G[0]};
-		b = {S32X_B,S32X_B[0],S32X_B[0],S32X_B[0]};
+		r = {S32X_R,S32X_R[4:2]};
+		g = {S32X_G,S32X_G[4:2]};
+		b = {S32X_B,S32X_B[4:2]};
 	end else begin
-		r = !S32X_YSO_N ? {S32X_R,S32X_R[0],S32X_R[0],S32X_R[0]} : color_lut[GEN_R];
-		g = !S32X_YSO_N ? {S32X_G,S32X_G[0],S32X_G[0],S32X_G[0]} : color_lut[GEN_G];
-		b = !S32X_YSO_N ? {S32X_B,S32X_B[0],S32X_B[0],S32X_B[0]} : color_lut[GEN_B];
+		r = !S32X_YSO_N ? {S32X_R,S32X_R[4:2]} : color_lut[GEN_R];
+		g = !S32X_YSO_N ? {S32X_G,S32X_G[4:2]} : color_lut[GEN_G];
+		b = !S32X_YSO_N ? {S32X_B,S32X_B[4:2]} : color_lut[GEN_B];
 	end
 end
 

--- a/rtl/32X/32X.sv
+++ b/rtl/32X/32X.sv
@@ -70,25 +70,26 @@ module S32X
 	output     [23:0] DBG_CA
 );
 	import S32X_PKG::*;
-	
+
+//53.693175
 	bit CE_R, CE_F;
 	always @(posedge CLK) begin
 		bit [2:0] CLK_CNT;
 		CLK_CNT <= CLK_CNT == 3'd6 ? 3'd0 : CLK_CNT + 3'd1;
 		
-//		CE_F <= 0;
-//		CE_R <= 0;
-//		case (CLK_CNT)
-//			3'd0: CE_F <= 1;
-//			3'd1: CE_R <= 1;
-//			3'd2: CE_F <= 1;
-//			3'd3: CE_R <= 1;
-//			3'd5: CE_F <= 1;
-//			3'd6: CE_R <= 1; 
-//			default:;
-//		endcase
-		CE_F <= ~CE_F;
-		CE_R <= CE_F;
+		CE_F <= 0;
+		CE_R <= 0;
+		case (CLK_CNT)
+			3'd0: CE_F <= 1;
+			3'd1: CE_R <= 1;
+			3'd2: CE_F <= 1;
+			3'd3: CE_R <= 1;
+			3'd5: CE_F <= 1;
+			3'd6: CE_R <= 1; 
+			default:;
+		endcase
+		// CE_F <= ~CE_F;
+		// CE_R <= CE_F;
 	end
 
 	bit  [26:0] SHA;

--- a/rtl/32X/32X.sv
+++ b/rtl/32X/32X.sv
@@ -71,25 +71,33 @@ module S32X
 );
 	import S32X_PKG::*;
 
-//53.693175
 	bit CE_R, CE_F;
+	// The SH2 clock ticks 3 full times for each VCLK
 	always @(posedge CLK) begin
-		bit [2:0] CLK_CNT;
-		CLK_CNT <= CLK_CNT == 3'd6 ? 3'd0 : CLK_CNT + 3'd1;
-		
+		bit [2:0] CLK_CNT = 3'b111;
+		if (~&CLK_CNT)
+			CLK_CNT <= CLK_CNT + 1'd1;
+
 		CE_F <= 0;
 		CE_R <= 0;
+	
+		if (VCLK) begin
+			CLK_CNT <= 1;
+			CE_F <= 1;
+		end
+
 		case (CLK_CNT)
 			3'd0: CE_F <= 1;
 			3'd1: CE_R <= 1;
 			3'd2: CE_F <= 1;
 			3'd3: CE_R <= 1;
-			3'd5: CE_F <= 1;
-			3'd6: CE_R <= 1; 
+			3'd4: CE_F <= 1;
+			3'd5: CE_R <= 1;
 			default:;
 		endcase
-		// CE_F <= ~CE_F;
-		// CE_R <= CE_F;
+
+		if (~RST_N)
+			CLK_CNT <= 3'b111;
 	end
 
 	bit  [26:0] SHA;


### PR DESCRIPTION
-Fix the PWM sound being too fast
-Adjust the clock divider to synchronize with VCLK to roughly mimic real hardware's PLL